### PR TITLE
Use snmp2_reak_walk to get object ID and fix regex match.

### DIFF
--- a/Printer/check_printer
+++ b/Printer/check_printer
@@ -144,7 +144,7 @@ function snmp_walk($oid) {
 		// snmp3_walk ( string $host , string $sec_name , string $sec_level , string $auth_protocol , string $auth_passphrase , string $priv_protocol , string $priv_passphrase , string $object_id )
 		$value = @snmp3_walk($ip, $sec_name ,$sec_level ,$auth_protocol ,$auth_passphrase ,$priv_protocol ,$priv_passphrase, $oid);
 	} else if ( $snmpversion == 'v2c' ) {
-		$value = @snmp2_walk($ip, $community, $oid);
+		$value = @snmp2_real_walk($ip, $community, $oid);
 	} else {
 		$value = @snmpwalkoid($ip, $community, $oid);
 	}
@@ -508,8 +508,8 @@ switch ( $command ) {
 		$mydata = array();
 		foreach ( $rawdata as $key => $val ) {
 				
-            //if ( !(preg_match ( "@SNMPv2-SMI::mib-2.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match ) || preg_match ( "@iso.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match )))
-            		if ( !(preg_match ( "@1.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match ) || preg_match ( "@iso.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match )))
+            if ( !(preg_match ( "@SNMPv2-SMI::mib-2.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match ) || preg_match ( "@iso.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match )))
+            //		if ( !(preg_match ( "@1.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match ) || preg_match ( "@iso.3.6.1.2.1.43.18.1.1.(?P<num>\d+).1.(?P<index>\d+)@", $key, $match )))
 				nagios_return ( 3, "Internal error" );
 
 			$mydata[(int)$match['index']][(int)$match['num']] = $val;

--- a/Printer/check_printer
+++ b/Printer/check_printer
@@ -82,7 +82,7 @@ function get_status ( $max, $cur, $warn, $crit ) {
 		}
 	} else {
 		if ( $cur == -3 ) {
-			return 0;
+			return 2;
 	        //Ricoh printers use -100 value to indicate 20%-1% or 10%-1% remaining toner
         	} else if ( $cur == -2 || $cur == -100 ) {
             		return 1;


### PR DESCRIPTION
snmp2_walk does not return object ids, but snmp2_real_walk does. The regex must be rewritten as in the first (commented) form.