### PR TITLE
check_fortigate.pl - added uptime, license, linkstatus, conserve, fortimanager health , fortimanager devicestatus

### DIFF
--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -490,6 +490,7 @@ sub get_ha_sync {
 }
 
 sub get_uptime {
+  my $valuemin;
   my $value = (get_snmp_value($session, $oid_uptime)/100);
   my ($days_val, $rem_d_value) = (int($value / 86400), $value / 86400);
   my $hours_val = int(($rem_d_value-$days_val) * 24);

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -928,7 +928,7 @@ sub get_sdwan_hc {
       my @sdwan_hc_failed;
 
       $return_state = "OK";
-      $return_string = "All SDWAN healt checks are in appropriate state";
+      $return_string = "All SDWAN health checks are in appropriate state";
 
       $k = 1;
       while ($k <= $sdwan_hc_cnt) {
@@ -947,7 +947,7 @@ sub get_sdwan_hc {
       }
 
    } else {
-      $return_string = "UNKNOWN: device has no SDWAN healt checks available";
+      $return_string = "UNKNOWN: device has no SDWAN health checks available";
       $return_state = "UNKNOWN";
    }
 

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -138,7 +138,7 @@ my %status = (     # Enumeration for the output Nagios states
 
 # Parse out the arguments...
 my ($ip, $port, $community, $type, $warn, $crit, $expected, $slave, $pri_serial, $reset_file, $mode, $vpnmode,
-    $blacklist, $whitelist, $nosync , $snmp_version, $user_name, $auth_password, $auth_prot, $priv_password, $priv_prot, $path) = parse_args();
+    $blacklist, $whitelist, $nosync, $snmp_version, $user_name, $auth_password, $auth_prot, $priv_password, $priv_prot, $path) = parse_args();
 
 # Initialize variables....
 my $net_snmp_debug_level = 0x00; # See http://search.cpan.org/~dtown/Net-SNMP-v6.0.1/lib/Net/SNMP.pm#debug()_-_set_or_get_the_debug_mode_for_the_module

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -138,7 +138,7 @@ my %status = (     # Enumeration for the output Nagios states
 
 # Parse out the arguments...
 my ($ip, $port, $community, $type, $warn, $crit, $expected, $slave, $pri_serial, $reset_file, $mode, $vpnmode,
-    $blacklist, $whitelist, $nosync, $ignoreexpiredlicense , $snmp_version, $user_name, $auth_password, $auth_prot, $priv_password, $priv_prot, $path) = parse_args();
+    $blacklist, $whitelist, $nosync , $snmp_version, $user_name, $auth_password, $auth_prot, $priv_password, $priv_prot, $path) = parse_args();
 
 # Initialize variables....
 my $net_snmp_debug_level = 0x00; # See http://search.cpan.org/~dtown/Net-SNMP-v6.0.1/lib/Net/SNMP.pm#debug()_-_set_or_get_the_debug_mode_for_the_module

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -269,9 +269,9 @@ given ( $curr_serial ) {
       }
    } when ( /^FMG/ ) { # FMG = FortiManager
       given ( lc($type) ) {
-         when ("cpu") { ($return_state, $return_string) = get_health_value($oid_faz_cpu_used, "CPU", "%"); }
-         when ("mem") { ($return_state, $return_string) = get_faz_health_value($oid_faz_mem_used, $oid_faz_mem_avail, "Memory", "%"); }
-         when ("disk") { ($return_state, $return_string) = get_faz_health_value($oid_faz_disk_used, $oid_faz_disk_avail, "Disk", "%"); }
+         when ("cpu") { ($return_state, $return_string) = get_health_value($oid_fmg_cpu_used, "CPU", "%"); }
+         when ("mem") { ($return_state, $return_string) = get_fmg_health_value($oid_fmg_mem_used, $oid_fmg_mem_avail, "Memory", "%"); }
+         when ("disk") { ($return_state, $return_string) = get_fmg_health_value($oid_fmg_disk_used, $oid_fmg_disk_avail, "Disk", "%"); }
          default { ($return_state, $return_string) = ('UNKNOWN',"UNKNOWN: This device supports only selected type -T cpu|mem|disk, $curr_device is a FORTIANALYZER (S/N: $curr_serial)"); }
       }
    } when ( /^FE/ ) { # FE = FORTIMAIL

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -7,11 +7,12 @@
 # Tested on: FortiGate 100D / FortiGate 300C (5.0.3)
 # Tested on: FortiGate 200B (5.0.6), Fortigate 800C (5.2.2)
 # Tested on: FortiAnalyzer (5.2.4)
+# Tested on: FortiManager (6.4.4)
 # Tested on: FortiGate 100A (2.8)
 # Tested on: FortiGate 800D (6.2.3)
 #
-# Author: Boris PASCAULT (github (at) ituz.fr)
-# Date: 2020-03-25
+# Author: Sebastian Gruber (github (at) sebastiangruber.de)
+# Date: 2021-02-10
 #
 # Changelog:
 # Release 1.0 (2013)

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -90,7 +90,7 @@
 # - Change regex for IPSec VPN monitoring (tested on Forti800D running FortiOS 6.2.3)
 # Release 1.8.6 (2021-04-06) Dariusz Zielinski-Kolasinski
 # - Add SD-WAN Health Check monitoring (tested on Forti900D running FortiOS 6.4.5, Forti60F 6.4.5)
-# Release 1.8.7 (2021-02-10) Sebastian Gruber  (github (at) sebastiangruber.de)
+# Release 1.8.7 (2021-05-31) Sebastian Gruber  (github (at) sebastiangruber.de)
 # - added FortiManager Checks (cpu, mem, disk)
 #
 # This program is free software; you can redistribute it and/or
@@ -119,7 +119,7 @@ use Socket;
 use POSIX;
 
 my $script = "check_fortigate.pl";
-my $script_version = "1.8.6";
+my $script_version = "1.8.7";
 
 # for more information.
 my %status = (     # Enumeration for the output Nagios states


### PR DESCRIPTION
- added: FortiManager Health Checks (cpu, mem, disk)
- added: FortiManager Health Checks for connected devices health (up/down) and config-sync State (fmgdevice)
- added: Fortigate Uptime warn (behaviour if warn is set)
- added: Fortigate License expiration Check monitoring for FortiGate with critical & warning (license)
- added: Fortigate License Version Check for scheduled Updates on FortiGate (license-version)
- added: Link-Monitor Health Check (alive,dead), tested on Forti900D running FortiOS 6.4.5, Forti60F 6.4.5
- added: FortiGate conserve mode for proxy and kernel (conserve-proxy , conserve-kernel)
- fixed: typo in SD-WANHealth

