### PR TITLE
check whitelist match

### DIFF
--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -829,6 +829,8 @@ sub get_vpn_state {
   my $ActiveSSL = 0;
   my $ActiveSSLTunnel = 0;
   my $return_string_errors = "";
+  my $return_string = "";
+  my $match_whitelist = undef;
 
   use constant {
     TUNNEL_DOWN => 1,
@@ -857,10 +859,18 @@ sub get_vpn_state {
     %tunnels_names  = map { (my $temp = $_ ) =~ s/^${oid_ipsectuntableroot}${oidf_tunname}\.//; $temp => $tunnels_names{$_}  } keys %tunnels_names;
     %tunnels_status = map { (my $temp = $_ ) =~ s/^${oid_ipsectuntableroot}${oidf_tunstatus}\.//; $temp => $tunnels_status{$_} } keys %tunnels_status;
 
-    if (defined($whitelist) and length($whitelist))
-    {
-      delete $tunnels_names{$_} for grep { $tunnels_names{$_} !~ $whitelist } keys %tunnels_names;
+    if (defined($whitelist) and length($whitelist)) {
+      my @matches = grep { $tunnels_names{$_} =~ $whitelist } keys %tunnels_names;
+      if (@matches) {
+          delete $tunnels_names{$_} for grep { $tunnels_names{$_} !~ $whitelist } keys %tunnels_names;
+	  $match_whitelist = 1;
+      } else {
+	  # Whitelist not match - need invertigate
+	  $return_string = "Whitelist not match any VPN name. ";
+	  $match_whitelist = 0;
+      }
     }
+
     if (defined($blacklist) and length($blacklist))
     {
       delete $tunnels_names{$_} for grep { $tunnels_names{$_} =~ $blacklist } keys %tunnels_names;
@@ -885,10 +895,11 @@ sub get_vpn_state {
   if (($mode >= 2 ) && ($vpnmode ne "ssl")) {
     if ($ipstunsdown == 1) { $return_state = "WARNING"; }
     if ($ipstunsdown >= 2) { $return_state = "CRITICAL"; }
+    if (defined($match_whitelist) and $match_whitelist == 0) { $return_state = "UNKNOWN"; }
   }
 
   # Write an output string...
-  $return_string = $return_state . ": " . $curr_device . " (Master: " . $curr_serial .")";
+  $return_string = $return_state . ": " . $return_string . $curr_device . " (Master: " . $curr_serial .")";
 
   if ($vpnmode ne "ipsec") {
     #Add the SSL tunnel count
@@ -902,16 +913,6 @@ sub get_vpn_state {
   $perf="|'ActiveSSL-VPN'=".$ActiveSSL." 'ActiveIPSEC'=".$ipstunsopen;
   $return_string .= $perf;
 
-  # Check to see if the output string contains either "unkw", "warning" or "down", and set an output state accordingly...
-  if($return_string =~/uknw/i){
-    $return_state = "UNKNOWN";
-  }
-  if($return_string =~/warning/i){
-    $return_state = "WARNING";
-  }
-  if($return_string =~/down/i){
-    $return_state = "CRITICAL";
-  }
   return ($return_state, $return_string);
 } # end vpn state
 

--- a/fortigate/check_fortigate.pl
+++ b/fortigate/check_fortigate.pl
@@ -893,8 +893,7 @@ sub get_vpn_state {
 }
   #Set Unitstate
   if (($mode >= 2 ) && ($vpnmode ne "ssl")) {
-    if ($ipstunsdown == 1) { $return_state = "WARNING"; }
-    if ($ipstunsdown >= 2) { $return_state = "CRITICAL"; }
+    if ($ipstunsdown >= 1) { $return_state = "CRITICAL"; }
     if (defined($match_whitelist) and $match_whitelist == 0) { $return_state = "UNKNOWN"; }
   }
 


### PR DESCRIPTION
Problem: In case the tunnel name is changed then whitleist regex may not match. Then the script returns **OK** status without checking any tunnel! 

Here is an example: 
Before renaming:
```
$ check_fortigate.pl -v 3 -H fg.mgmt.internal -U nagios -A auth -a sha1 -X pass -x AES -T VPN -V ipsec -W “Lion”
OK: fg1.mgmt.internal (Master: FGT90GTKXXXXX): IPSEC Tunnels: Configured/Active: 1/1 |'ActiveSSL-VPN'=0 'ActiveIPSEC'=1
```

After renaming (does not detect any tunnel and returns ok):
```
$ check_fortigate.pl -v 3 -H fortigate.internal -U nagios -A auth -a sha1 -X pass -x AES -T VPN -V ipsec -W “Lion”
OK: fg1.mgmt.interna (Master: FGT90GTKXXXXX): IPSEC Tunnels: Configured/Active: 0/0 |'ActiveSSL-VPN'=0 'ActiveIPSEC'=0
```

The changes are intended to give feedback that the whitelist does not cover anything and no tunnel is checked. The status returned is UNKNOWN. 

Here's an example of what the response looks like (status unknown, message and general summary): 
```
$ check_fortigate.pl -v 3 -H fortigate.internal -U nagios -A auth -a sha1 -X pass -x AES -T VPN -V ipsec -W “Lion”
UNKNOWN: Whitelist not match any VPN name. fg1.mgmt.internal (Master: FGT90GTKXXXXX): IPSEC Tunnels: Configured/Active: 3/2 DOWN[Exadata]|'ActiveSSL-VPN'=0 'ActiveIPSEC'=2
```
